### PR TITLE
fix: footnote-after-punctuation containing hyphen

### DIFF
--- a/src/rules/footnote-after-punctuation.ts
+++ b/src/rules/footnote-after-punctuation.ts
@@ -19,7 +19,9 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
     return FootnoteAfterPunctuationOptions;
   }
   apply(text: string, options: FootnoteAfterPunctuationOptions): string {
-    return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
+    // Matches a footnote reference containing any text except newlines and the
+    // terminating ].
+    return text.replace(/(\[\^[^\]]+\]) ?([,.;!:?])/gm, '$2$1');
   }
   get exampleBuilders(): ExampleBuilder<FootnoteAfterPunctuationOptions>[] {
     return [


### PR DESCRIPTION
This allows symbols to appear in footnote references without breaking the `footnote-after-punctuation` lint.

I'm not sure how to include tests for this but I'm happy to if you can point me in the right direction :+1:

Fixes https://github.com/platers/obsidian-linter/issues/1112.

---

* fix: footnote-after-punctuation containing hyphen (10b7dac)
      
      Fixes the footnote-after-punctuation rewriting for footnote references
      that contain hyphens (or other symbols):
      
        * Bananas[^test].
        * Bananas[^test-me].
        * Bananas[^test.2].
      
      Is now rewrote to:
      
        * Bananas.[^test]
        * Bananas.[^test-me]   <-- fixed
        * Bananas.[^test.2]    <-- fixed
      
      Fixes https://github.com/platers/obsidian-linter/issues/1112.